### PR TITLE
Add helmet security options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,22 @@
+export PORT=3000
 export COOKIE_SECRET=cookie
 export DEBUG=
+
+export MONGODB_URL=mongodb://localhost/weblitmapper
+
+# Webmaker connect API key
+export WMCONNECT_API_KEY='your Webmaker Connect API secret goes here'
+
+export WMCONNECT_API_SECRET='your Webmaker Connect API secret goes here'
+
+# Disable HSTS? (set to 'true' to disable HSTS)
+export HSTS_DISABLED='true'
+
+# Use Deny settings for X-Frame headers?
+# set to 'true' to disable X-frames-options denial
+export DISABLE_XFO_HEADERS_DENY='true'
+
+# Use default XSS protection?
+# set to 'true' to disable IEXSS protection
+export IEXSS_PROTECTION_DISABLED='true'
+

--- a/lib/app.js
+++ b/lib/app.js
@@ -8,6 +8,7 @@ var writeBundle = require('./write-bundle');
 var securityHeaders = require('./security-headers');
 var webmakerConnect = require('./webmaker-connect');
 var website = require('./website');
+var helmet = require('helmet');
 
 exports.build = function(options) {
   var app = express();
@@ -33,6 +34,20 @@ exports.build = function(options) {
   });
 
   if (options.defineExtraMiddleware) options.defineExtraMiddleware(app);
+
+  // Security header options from helmet
+  if (process.env.HSTS_DISABLED != 'true') {
+    // Use HSTS
+    app.use(helmet.hsts());
+  }
+  if (process.env.DISABLE_XFO_HEADERS_DENY != 'true') {
+    // No xframes allowed
+    app.use(helmet.xframe('deny'));
+  }
+  if (process.env.IEXSS_PROTECTION_DISABLED != 'true') {
+  // Use XSS protection
+    app.use(helmet.iexss());
+  }
 
   app.use(app.router);
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "async": "0.7.0",
+    "helmet": "0.2.1",
     "oauth": "0.9.11",
     "mongoose": "3.8.8",
     "express": "3.4.4",


### PR DESCRIPTION
Adds some env options:
# Disable HSTS? (set to 'true' to disable HSTS)

export HSTS_DISABLED='true'
# Use Deny settings for X-Frame headers?
# set to 'true' to disable X-frames-options denial

export DISABLE_XFO_HEADERS_DENY='true'
# Use default XSS protection?
# set to 'true' to disable IEXSS protection

export IEXSS_PROTECTION_DISABLED='true'

These, when set to not disable them, will add x-frame-options deny headers, hsts headers, and iexss protection.
